### PR TITLE
use text string for WKT-CRS

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -408,35 +408,11 @@ Example of a vertical CRS, here representing height above the NAV88 datum:
 ```
 
 #### 5.1.4 Providing inline definitions of CRSs
-Sometimes there may be no well-known identifier for a geospatial CRS. Or the data provider may wish to make the CoverageJSON file more self-contained by avoiding external lookups. In this case a full inline definition of the CRS in JSON (instead of, or in addition to the `"id"`). This has not yet been fully defined in this specification, but we recommend following the OGC Well-Known Text (WKT) structure, for example:
+Sometimes there may be no well-known identifier for a geospatial CRS. Or the data provider may wish to make the CoverageJSON file more self-contained by avoiding external lookups. In this case a full inline definition of the CRS in JSON (instead of, or in addition to the `"id"`) may be provided. 
 
-```json
-{
-  "type": "VerticalCRS",
-  "id": "http://www.opengis.net/def/crs/EPSG/0/5703",
-  "datum": {
-    "id": "http://www.opengis.net/def/datum/EPSG/0/5103",
-    "label": {
-      "en": "North American Vertical Datum 1988"
-    }
-  },
-  "cs": {
-    "id": "http://www.opengis.net/def/cs/EPSG/0/6499",
-    "csAxes": [{
-      "id": "http://www.opengis.net/def/axis/EPSG/0/114",
-      "name": {
-        "en": "Gravity-related height"
-      },
-      "direction": "up",
-      "unit": {
-        "symbol": "m"
-      }
-    }]
-  }
-}
-```
+It is recommended that a Well-Known Text Coordinate Reference System String, conforming to the OGC WKT-CRS and ISO19162 joint  specification is included as a string attribute.
 
-In future work, a mapping from OGC WKT2 to JSON may be defined, and may be adopted into the CoverageJSON specification.
+The attribute name shall be `"WKTCRS"`.
 
 
 ### 5.2. Temporal Reference Systems


### PR DESCRIPTION
I think it is beyond the scope of CovJSON to produce a JSON encoding of WKT-CRS.  

Prefer the use of WKT strings as-is in CovJSON documents (as string values) represents a sensible position to take at this time.

My sense is that it is a treacherous path to include such a re-encoding of another standard within this specification.

I would suggest that initially this section be removed, following a consultation on who may be using it.

We can highlight the desire to encode WKT-CRS within JSON payloads to the Maintainers of CRS-WKT and request input on how to do this effectively.
I suspect that, at a minimum, it would require the publishing of the controlled vocabularies encoded within the WKT-CRS specification.

Does this raise concerns with contributors?

Would further information help this section?