### PR TITLE
Prefer epsg

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -371,7 +371,7 @@ Example of a three-dimensional geographic CRS (latitude-longitude-height):
 ```json
 {
   "type": "GeographicCRS",
-  "id": "http://www.opengis.net/def/crs/EPSG/0/4979"
+  "id": "https://www.epsg-registry.org/export.htm?wkt=urn:ogc:def:crs:EPSG::4979"
 }
 ```
 
@@ -383,12 +383,12 @@ Projected CRSs use two coordinates to denote positions on a Cartesian plane, whi
 
 If a Coverage conforms to one of the defined [domain types][domain-types] then the coordinate identifier `"x"` is used to denote easting and `"y"` is used for northing.
 
-Example of a projected CRS (here [British National Grid](http://spatialreference.org/ref/epsg/osgb-1936-british-national-grid/)):
+Example of a projected CRS (here [British National Grid](https://www.epsg-registry.org/export.htm?wkt=urn:ogc:def:crs:EPSG::27700)):
 
 ```json
 {
   "type": "ProjectedCRS",
-  "id": "http://www.opengis.net/def/crs/EPSG/0/27700"
+  "id": "https://www.epsg-registry.org/export.htm?wkt=urn:ogc:def:crs:EPSG::27700"
 }
 ```
 
@@ -403,7 +403,7 @@ Example of a vertical CRS, here representing height above the NAV88 datum:
 ```json
 {
   "type": "VerticalCRS",
-  "id": "http://www.opengis.net/def/crs/EPSG/0/5703"
+  "id": "https://www.epsg-registry.org/export.htm?wkt=urn:ogc:def:crs:EPSG::5703"
 }
 ```
 
@@ -461,7 +461,7 @@ In this specification, only a string-based notation for time values is defined.
   a client SHOULD interpret those dates in that reduced precision.
 
 Example:
-
+ep
 ```json
 {
   "type": "TemporalRS",
@@ -608,7 +608,7 @@ Example of a reference system connection object:
   "coordinates": ["y","x","z"],
   "system": {
     "type": "GeographicCRS",
-    "id": "http://www.opengis.net/def/crs/EPSG/0/4979"
+    "id": "https://www.epsg-registry.org/export.htm?wkt=urn:ogc:def:crs:EPSG::4979"
   }
 }
 ```
@@ -637,7 +637,7 @@ Example of a domain object with [`"Grid"`][domain-types] domain type:
     "coordinates": ["y","x","z"],
     "system": {
       "type": "GeographicCRS",
-      "id": "http://www.opengis.net/def/crs/EPSG/0/4979"
+      "id": "https://www.epsg-registry.org/export.htm?wkt=urn:ogc:def:crs:EPSG::4979"
     }
   }]
 }

--- a/spec.md
+++ b/spec.md
@@ -461,7 +461,7 @@ In this specification, only a string-based notation for time values is defined.
   a client SHOULD interpret those dates in that reduced precision.
 
 Example:
-ep
+
 ```json
 {
   "type": "TemporalRS",


### PR DESCRIPTION
* Prefer http://epsg-registry.org to http://www.opengis.net/def/

In the CovJSON specification there are numerous references to http://www.opengis.net/def/ where this OGC resource is being used to reference a EPSG published Coordinate Reference System definition.

The EPSG registry is responsible for publishing the EPSG referenced content, the OGC resource can only ever follow, and is unhelpfully inconsistent at times.

I think that the examples within CovJSON of referencing EPSG codes would be better directly referencing the source of these.

Additionally, the OGC resources publish GML encodings of CRS specifications.  Whilst this can be seen as consistent for GML based applications, it is not well matched to a JSON encoding.
The Well Known Text encoding is much better suited to human and JSON clients, I believe.

In this change I propose using the http://epsg-registry.org resources and the WKT exports as identifying URIs for CRSs.

I have not proposed a mandate, this is not a compulsion, and it does not assume that EPSG meets all requirements.

This proposed change does recognise that publishing a CRS definition from the maintainers, not republished by a third party, and in a format more suitable for use directly within the encoding, may represent an improvement.